### PR TITLE
Add Realm for WWW-Authenticate header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,8 @@ Metrics/BlockLength:
     - spec/**/*.rb
 Metrics/ClassLength:
   Max: 220
+  Exclude:
+    - lib/cerner/oauth1a/access_token.rb
 Metrics/CyclomaticComplexity:
   Exclude:
     - lib/cerner/oauth1a/access_token.rb
@@ -28,6 +30,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Exclude:
     - lib/cerner/oauth1a/access_token.rb
+    - lib/cerner/oauth1a/oauth_error.rb
 Style/GuardClause:
   Exclude:
     - lib/cerner/oauth1a/access_token.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.1.0
+Added an attribute for the Protection Realm to Cerner::OAuth1a::AccessTokenAgent, 
+Cerner::OAuth1a::AccessToken, and Cerner::OAuth1a::OAuthError. This value will be
+parsed as the canonical root URI of the agent's configured access_token_url. When
+this value is available, it will be added to errors and generated authorization
+headers.
+
 # v2.0.1
 Allow parsing authorization headers that do not include an oauth_version parameter as per
 the spec:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,3 @@
 * Cerner Corporation
 * Nathan Beyer [@nbeyer](https://github.com/nbeyer)
-* John leacox [@johnlcox](https://github.com/johnlcox)
+* John Leacox [@johnlcox](https://github.com/johnlcox)

--- a/lib/cerner/oauth1a/access_token.rb
+++ b/lib/cerner/oauth1a/access_token.rb
@@ -183,7 +183,7 @@ module Cerner
         raise ArgumentError, 'access_token_agent is nil' unless access_token_agent
 
         if @realm && !@realm.eql?(access_token_agent.realm)
-          raise OAuthError.new('realm does not match provider', nil, 'realm_rejected', nil, access_token_agent.realm)
+          raise OAuthError.new('realm does not match provider', nil, 'token_rejected', nil, access_token_agent.realm)
         end
 
         # Set realm to the provider's realm if it's not already set

--- a/lib/cerner/oauth1a/access_token.rb
+++ b/lib/cerner/oauth1a/access_token.rb
@@ -13,11 +13,6 @@ module Cerner
       # Public: Constructs an AccessToken using the value of an HTTP Authorization Header based on
       # the OAuth HTTP Authorization Scheme (https://oauth.net/core/1.0a/#auth_header).
       #
-      # If this token is associated to a particular realm (e.g. will be authenticated against a
-      # particular agent), then use AccessTokenAgent#from_authorization_header of the corresponding
-      # agent pass the optional realm value. Otherwise the realm will be nil or parsed from the value in
-      # the header (which will perform no realm validation).
-      #
       # value - A String containing the HTTP Authorization Header value.
       #
       # Returns an AccessToken.

--- a/lib/cerner/oauth1a/access_token_agent.rb
+++ b/lib/cerner/oauth1a/access_token_agent.rb
@@ -146,26 +146,6 @@ module Cerner
         access_token
       end
 
-      # Public: Constructs an AccessToken using the realm of this agent and the value of an HTTP
-      # Authorization Header based on the OAuth HTTP Authorization Scheme (https://oauth.net/core/1.0a/#auth_header).
-      #
-      # value - A String containing the HTTP Authorization Header value.
-      #
-      # Returns an AccessToken.
-      #
-      # Raises a Cerner::OAuth1a::OAuthError with a populated oauth_problem and realm of this agent
-      # if any of the parameters in the value are invalid.
-      def from_authorization_header(value)
-        params = Protocol.parse_authorization_header(value)
-
-        unless params[:realm].nil? || params[:realm]&.eql?(@realm)
-          raise OAuthError.new('', nil, 'realm_rejected', nil, @realm)
-        end
-
-        # TODO: Is there a better way to get the realm into the token if it's not in the request header?
-        AccessToken.from_authorization_header(value, @realm)
-      end
-
       # Public: Generate an Accessor Secret for invocations of the Access Token service.
       #
       # Returns a String containing the secret.

--- a/lib/cerner/oauth1a/access_token_agent.rb
+++ b/lib/cerner/oauth1a/access_token_agent.rb
@@ -226,9 +226,8 @@ module Cerner
       def canonical_root_url_for(url)
         raise ArgumentError, 'url is nil' unless url
 
-        realm = "#{url.scheme}://#{url.host}"
-        realm += ":#{url.port}" unless url.port == url.default_port
-        realm
+        realm = URI("#{url.scheme}://#{url.host}:#{url.port}")
+        realm.to_s
       end
 
       # Internal: Prepare a request for #retrieve

--- a/lib/cerner/oauth1a/access_token_agent.rb
+++ b/lib/cerner/oauth1a/access_token_agent.rb
@@ -227,7 +227,7 @@ module Cerner
         raise ArgumentError, 'url is nil' unless url
 
         realm = "#{url.scheme}://#{url.host}"
-        realm += ":#{url.port}" unless url.port == 80 || url.port == 443
+        realm += ":#{url.port}" unless url.port == url.default_port
         realm
       end
 

--- a/lib/cerner/oauth1a/oauth_error.rb
+++ b/lib/cerner/oauth1a/oauth_error.rb
@@ -46,9 +46,9 @@ module Cerner
         parts = []
         parts << message if message
         parts << "HTTP #{@http_response_code}" if @http_response_code
-        parts << "OAuth Realm #{@realm}" if @realm # TODO: Should this keep the order of the .initialize parameters?
         parts << "OAuth Problem #{@oauth_problem}" if @oauth_problem
         parts << "OAuth Parameters [#{@oauth_parameters.join(', ')}]" if @oauth_parameters
+        parts << "OAuth Realm #{@realm}" if @realm
         super(parts.empty? ? nil : parts.join(' '))
       end
 

--- a/lib/cerner/oauth1a/protocol.rb
+++ b/lib/cerner/oauth1a/protocol.rb
@@ -69,11 +69,14 @@ module Cerner
       #
       #   params = { realm: 'https://test.host', oauth_problem: 'token_expired' }
       #   Cerner::OAuth1a::Protocol.generate_www_authenticate_header(params)
-      #   # => "OAuth realm=\"https%3A%2F%2Ftest.host\",oauth_problem=\"token_expired\""
+      #   # => "OAuth realm=\"https://test.host\",oauth_problem=\"token_expired\""
       #
       # Returns the String containing the generated value or nil if params is nil or empty.
       def self.generate_authorization_header(params)
         return nil unless params && !params.empty?
+
+        realm = "realm=\"#{params.delete(:realm)}\"" if params[:realm]
+        realm += ', ' if realm && !params.empty?
 
         encoded_params = params.map do |k, v|
           k = URI.encode_www_form_component(k).gsub('+', '%20')
@@ -81,7 +84,7 @@ module Cerner
           "#{k}=\"#{v}\""
         end
 
-        'OAuth ' + encoded_params.join(',')
+        "OAuth #{realm}#{encoded_params.join(',')}"
       end
 
       # Alias the parse and generate methods

--- a/spec/cerner/oauth1a/access_token_spec.rb
+++ b/spec/cerner/oauth1a/access_token_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(ata).to receive(:realm).twice.and_return('AGENT REALM')
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
-          expect(error.message).to include 'realm_rejected'
+          expect(error.message).to include 'token_rejected'
           expect(error.realm).to eq('AGENT REALM')
         end
       end

--- a/spec/cerner/oauth1a/access_token_spec.rb
+++ b/spec/cerner/oauth1a/access_token_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
       it 'when oauth_version is not 1.0' do
         expect do
           Cerner::OAuth1a::AccessToken.from_authorization_header(
-            'OAuth oauth_version="1.1", ' \
+            'OAuth realm="realm", ' \
+            'oauth_version="1.1", ' \
             'oauth_consumer_key="consumer key", ' \
             'oauth_nonce="nonce", ' \
             'oauth_timestamp="1", ' \
@@ -26,7 +27,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
       it 'when oauth_consumer_key is missing' do
         expect do
           Cerner::OAuth1a::AccessToken.from_authorization_header(
-            'OAuth oauth_version="1.0", ' \
+            'OAuth realm="realm", ' \
+            'oauth_version="1.0", ' \
             'oauth_nonce="nonce", ' \
             'oauth_timestamp="1", ' \
             'oauth_token="token", ' \
@@ -117,11 +119,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: Time.now,
           token: 'TOKEN',
-          signature_method: 'REJECT_THIS'
+          signature_method: 'REJECT_THIS',
+          realm: 'REALM'
         )
-        expect { at.authenticate(double('AccessTokenAgent')) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /signature_method_rejected/)
-        )
+        expect { at.authenticate(double('AccessTokenAgent')) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'signature_method_rejected'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when consumer keys do not match' do
@@ -129,11 +134,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: 'ConsumerKey=WRONG%20CONSUMER%20KEY'
+          token: 'ConsumerKey=WRONG%20CONSUMER%20KEY',
+          realm: 'REALM'
         )
-        expect { at.authenticate(double('AccessTokenAgent')) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /consumer_key_rejected/)
-        )
+        expect { at.authenticate(double('AccessTokenAgent')) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'consumer_key_rejected'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when ExpiresOn is missing' do
@@ -141,11 +149,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: 'ConsumerKey=CONSUMER%20KEY'
+          token: 'ConsumerKey=CONSUMER%20KEY',
+          realm: 'REALM'
         )
-        expect { at.authenticate(double('AccessTokenAgent')) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /missing ExpiresOn/)
-        )
+        expect { at.authenticate(double('AccessTokenAgent')) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'missing ExpiresOn'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when ExpiresOn has expired' do
@@ -153,11 +164,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i - 60}"
+          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i - 60}",
+          realm: 'REALM'
         )
-        expect { at.authenticate(double('AccessTokenAgent')) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /token_expired/)
-        )
+        expect { at.authenticate(double('AccessTokenAgent')) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'token_expired'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when KeysVersion is missing' do
@@ -165,11 +179,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}"
+          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}",
+          realm: 'REALM'
         )
-        expect { at.authenticate(double('AccessTokenAgent')) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /missing KeysVersion/)
-        )
+        expect { at.authenticate(double('AccessTokenAgent')) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'missing KeysVersion'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when retrieve_keys fails' do
@@ -177,15 +194,18 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=2"
+          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=2",
+          realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
         expect(ata).to(
           receive(:retrieve_keys).with('2').and_raise(Cerner::OAuth1a::OAuthError, 'invalid keys')
         )
-        expect { at.authenticate(ata) }.to(
-          raise_error(Cerner::OAuth1a::OAuthError, /token references invalid keys version/)
-        )
+        expect { at.authenticate(ata) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'token references invalid keys version'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when token is not authentic' do
@@ -193,13 +213,18 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           consumer_key: 'CONSUMER KEY',
           nonce: 'NONCE',
           timestamp: Time.now,
-          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=1"
+          token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=1",
+          realm: 'REALM'
         )
         keys = double('Keys')
         expect(keys).to receive(:verify_rsasha1_signature).and_return(false)
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect { at.authenticate(ata) }.to raise_error(Cerner::OAuth1a::OAuthError, /not authentic/)
+        expect { at.authenticate(ata) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'not authentic'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when signature is missing' do
@@ -208,13 +233,18 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: Time.now,
           token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=1",
-          signature: 'SIGNATURE'
+          signature: 'SIGNATURE',
+          realm: 'REALM'
         )
         keys = double('Keys')
         expect(keys).to receive(:verify_rsasha1_signature).and_return(true)
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect { at.authenticate(ata) }.to raise_error(Cerner::OAuth1a::OAuthError, /missing HMACSecrets/)
+        expect { at.authenticate(ata) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'missing HMACSecrets'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when HMACSecrets fail to decrypt' do
@@ -223,14 +253,19 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: Time.now,
           token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=1&HMACSecrets=SECRETS",
-          signature: 'SIGNATURE'
+          signature: 'SIGNATURE',
+          realm: 'REALM'
         )
         keys = double('Keys')
         expect(keys).to receive(:verify_rsasha1_signature).and_return(true)
         expect(keys).to receive(:decrypt_hmac_secrets).with('SECRETS').and_raise(ArgumentError, 'SIMULATED_FAILURE')
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect { at.authenticate(ata) }.to raise_error(Cerner::OAuth1a::OAuthError, /SIMULATED_FAILURE/)
+        expect { at.authenticate(ata) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'SIMULATED_FAILURE'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when signature does not match secrets' do
@@ -239,7 +274,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: Time.now,
           token: "ConsumerKey=CONSUMER+KEY&ExpiresOn=#{Time.now.utc.to_i + 60}&KeysVersion=1&HMACSecrets=SECRETS",
-          signature: 'SIGNATURE'
+          signature: 'SIGNATURE',
+          realm: 'REALM'
         )
         keys = double('Keys')
         expect(keys).to receive(:verify_rsasha1_signature).and_return(true)
@@ -250,7 +286,11 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         )
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect { at.authenticate(ata) }.to raise_error(Cerner::OAuth1a::OAuthError, /signature_invalid/)
+        expect { at.authenticate(ata) }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'signature_invalid'
+          expect(error.realm).to eq('REALM')
+        end
       end
     end
 
@@ -312,7 +352,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         nonce: 'NONCE',
         timestamp: Time.at(Time.now.to_i),
         token: 'TOKEN',
-        token_secret: 'TOKEN SECRET'
+        token_secret: 'TOKEN SECRET',
+        realm: 'REALM'
       )
       hash = access_token.to_h
       expect(hash[:accessor_secret]).to eq(access_token.accessor_secret)
@@ -322,6 +363,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
       expect(hash[:timestamp]).to eq(access_token.timestamp)
       expect(hash[:token]).to eq(access_token.token)
       expect(hash[:token_secret]).to eq(access_token.token_secret)
+      expect(hash[:realm]).to eq(access_token.realm)
     end
   end
 
@@ -336,7 +378,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         nonce: 'NONCE',
         timestamp: current_time,
         token: 'TOKEN',
-        token_secret: 'TOKEN SECRET'
+        token_secret: 'TOKEN SECRET',
+        realm: 'REALM'
       )
     end
 
@@ -356,7 +399,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: current_time,
           token: 'TOKEN',
-          token_secret: 'TOKEN SECRET'
+          token_secret: 'TOKEN SECRET',
+          realm: 'REALM'
         )
 
         expect(access_token.object_id).not_to eq(access_token2.object_id)
@@ -372,7 +416,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: current_time,
           token: 'TOKEN',
-          token_secret: 'TOKEN SECRET'
+          token_secret: 'TOKEN SECRET',
+          realm: 'REALM'
         )
 
         expect(access_token2.authorization_header).not_to be_nil
@@ -480,6 +525,21 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(access_token == access_token2).to be false
         expect(access_token.eql?(access_token2)).to be false
       end
+
+      it 'when realm varies' do
+        access_token2 = Cerner::OAuth1a::AccessToken.new(
+          accessor_secret: 'ACCESSOR SECRET',
+          consumer_key: 'CONSUMER KEY',
+          expires_at: expires_at,
+          nonce: 'NONCE',
+          timestamp: current_time,
+          token: 'TOKEN',
+          token_secret: 'TOKEN SECRET',
+          realm: 'NOT REALM'
+        )
+        expect(access_token == access_token2).to be false
+        expect(access_token.eql?(access_token2)).to be false
+      end
     end
   end
 
@@ -508,9 +568,14 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           timestamp: current_time,
           token: 'TOKEN',
           token_secret: 'TOKEN SECRET',
-          signature_method: 'REJECT_THIS'
+          signature_method: 'REJECT_THIS',
+          realm: 'REALM'
         )
-        expect { at.authorization_header }.to raise_error(Cerner::OAuth1a::OAuthError, /signature_method_rejected/)
+        expect { at.authorization_header }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'signature_method_rejected'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
       it 'when signature is calculated and accessor_secret is nil' do
@@ -521,12 +586,17 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           nonce: 'NONCE',
           timestamp: current_time,
           token: 'TOKEN',
-          token_secret: 'TOKEN SECRET'
+          token_secret: 'TOKEN SECRET',
+          realm: 'REALM'
         )
-        expect { at.authorization_header }.to raise_error(Cerner::OAuth1a::OAuthError, /parameter_absent/)
+        expect { at.authorization_header }.to raise_error do |error|
+          expect(error).to be_a(Cerner::OAuth1a::OAuthError)
+          expect(error.message).to include 'parameter_absent'
+          expect(error.realm).to eq('REALM')
+        end
       end
 
-      it 'when signature is calculated and accessor_secret is nil' do
+      it 'when signature is calculated and token_secret is nil' do
         at = Cerner::OAuth1a::AccessToken.new(
           accessor_secret: 'ACCESSOR SECRET',
           consumer_key: 'CONSUMER KEY',

--- a/spec/cerner/oauth1a/oauth_error_spec.rb
+++ b/spec/cerner/oauth1a/oauth_error_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe Cerner::OAuth1a::OAuthError do
       oauth_error = Cerner::OAuth1a::OAuthError.new('MESSAGE', 401, 'parameter_absent', 'param1', 'http://example.com')
       expect(oauth_error.message).to eq('MESSAGE ' \
                                         'HTTP 401 ' \
-                                        'OAuth Realm http://example.com ' \
                                         'OAuth Problem parameter_absent ' \
-                                        'OAuth Parameters [param1]')
+                                        'OAuth Parameters [param1] ' \
+                                        'OAuth Realm http://example.com')
       expect(oauth_error.http_response_code).to eq(401)
       expect(oauth_error.oauth_problem).to eq('parameter_absent')
       expect(oauth_error.oauth_parameters).to eq(['param1'])

--- a/spec/cerner/oauth1a/oauth_error_spec.rb
+++ b/spec/cerner/oauth1a/oauth_error_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe Cerner::OAuth1a::OAuthError do
       expect(oauth_error.oauth_problem).to eq('parameter_absent')
       expect(oauth_error.oauth_parameters).to eq(['param1', 'param2'])
     end
+
+    it 'constructs with message and realm' do
+      oauth_error = Cerner::OAuth1a::OAuthError.new('MESSAGE', nil, nil, nil, 'http://example.com')
+      expect(oauth_error.message).to eq('MESSAGE OAuth Realm http://example.com')
+      expect(oauth_error.http_response_code).to be_nil
+      expect(oauth_error.oauth_problem).to be_nil
+      expect(oauth_error.oauth_parameters).to be_nil
+      expect(oauth_error.realm).to eq('http://example.com')
+    end
+
+    it 'constructs with message, HTTP response code, OAuth Problem, one OAuth Parameter, and realm' do
+      oauth_error = Cerner::OAuth1a::OAuthError.new('MESSAGE', 401, 'parameter_absent', 'param1', 'http://example.com')
+      expect(oauth_error.message).to eq('MESSAGE ' \
+                                        'HTTP 401 ' \
+                                        'OAuth Realm http://example.com ' \
+                                        'OAuth Problem parameter_absent ' \
+                                        'OAuth Parameters [param1]')
+      expect(oauth_error.http_response_code).to eq(401)
+      expect(oauth_error.oauth_problem).to eq('parameter_absent')
+      expect(oauth_error.oauth_parameters).to eq(['param1'])
+      expect(oauth_error.realm).to eq('http://example.com')
+    end
   end
 
   describe '#to_http_www_authenticate_header' do
@@ -69,14 +91,12 @@ RSpec.describe Cerner::OAuth1a::OAuthError do
       end
     end
 
-    context 'returns nil' do
-      it 'when oauth_problem is not present' do
-        oe = Cerner::OAuth1a::OAuthError.new('message')
-        expect(oe.to_http_www_authenticate_header).to be_nil
-      end
-    end
-
     context 'returns String' do
+      it 'when oauth_problem is nil but realm is present' do
+        oe = Cerner::OAuth1a::OAuthError.new('message', nil, nil, nil, 'http://example.org')
+        expect(oe.to_http_www_authenticate_header).to eq('OAuth realm="http://example.org"')
+      end
+
       it 'when oauth_problem is present' do
         oe = Cerner::OAuth1a::OAuthError.new('message', nil, 'token_rejected')
         expect(oe.to_http_www_authenticate_header).to eq('OAuth oauth_problem="token_rejected"')

--- a/spec/cerner/oauth1a/protocol_spec.rb
+++ b/spec/cerner/oauth1a/protocol_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Cerner::OAuth1a::Protocol do
           Cerner::OAuth1a::Protocol.generate_authorization_header(params)
         ).to eq('OAuth key%3Dkey="value1%2Fvalue2"')
       end
+
+      context 'with the realm parameter not percent-encoded' do
+        it 'when params has only the realm entry' do
+          expect(
+            Cerner::OAuth1a::Protocol.generate_authorization_header(realm: 'http://example.com')
+          ).to eq('OAuth realm="http://example.com"')
+        end
+
+        it 'when params has the realm entry and another entry' do
+          expect(
+            Cerner::OAuth1a::Protocol.generate_authorization_header(key: 'value', realm: 'http://example.com')
+          ).to eq('OAuth realm="http://example.com", key="value"')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

Adds additional functionality around a Protection Realm:
1. The protection realm of an agent is parsed as the canonical root URI of the `access_token_url`.
1. The protection realm attribute is added to both AccessToken and OAuthError.
1. The generated authorization header now includes the realm, when available.

### Additional Details

To avoid making breaking changes to the API, the new realm parameter is optional in most places. In some error cases, this made it hard to have a realm value available at all. 

For consumers of this library that care about the realm, I still wanted to provide a way to guarantee a realm would be present for errors/challenges. The main way this guarantee can be made is through the new `AccessTokenAgent#from_authorization_header` which functions similarly to `AccessToken#from_authorization_header` but also validates the request header realm against the agent realm, and sets the token's realm if no realm parameter is present.

Some specs have been added or modified, but more specs are needed. Prior to writing a full set of specs I wanted to get the API changes looked at as I do have a couple questions (which I will post inline).

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Cerner OAuth 1.0a Client Library.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
