### PR TITLE
Add support for parsing tokens with no version parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v2.1.0
+Allow parsing authorization headers that do not include an oauth_version parameter as per
+the spec:
+
+```
+oauth_version:
+  OPTIONAL. If present, value MUST be 1.0 . Service Providers MUST assume the protocol
+  version to be 1.0 if this parameter is not present. Service Providers' response to
+  non-1.0 value is left undefined.
+```
+
 # v2.0.0
 Added APIs for authenticating Access Tokens, so that service providers can be implemented
 with this library. Additionally, caching mechanisms for AccessTokens and Keys has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.1.0
+# v2.0.1
 Allow parsing authorization headers that do not include an oauth_version parameter as per
 the spec:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 * Cerner Corporation
 * Nathan Beyer [@nbeyer](https://github.com/nbeyer)
+* John leacox [@johnlcox](https://github.com/johnlcox)

--- a/lib/cerner/oauth1a/access_token.rb
+++ b/lib/cerner/oauth1a/access_token.rb
@@ -22,7 +22,7 @@ module Cerner
       def self.from_authorization_header(value)
         params = Protocol.parse_authorization_header(value)
 
-        unless params[:oauth_version].nil? || params[:oauth_version]&.eql?('1.0')
+        if params[:oauth_version] && !params[:oauth_version].eql?('1.0')
           raise OAuthError.new('', nil, 'version_rejected')
         end
 

--- a/lib/cerner/oauth1a/access_token.rb
+++ b/lib/cerner/oauth1a/access_token.rb
@@ -22,7 +22,9 @@ module Cerner
       def self.from_authorization_header(value)
         params = Protocol.parse_authorization_header(value)
 
-        raise OAuthError.new('', nil, 'version_rejected') unless params[:oauth_version]&.eql?('1.0')
+        unless params[:oauth_version].nil? || params[:oauth_version]&.eql?('1.0')
+          raise OAuthError.new('', nil, 'version_rejected')
+        end
 
         missing_params = []
         consumer_key = params[:oauth_consumer_key]

--- a/spec/cerner/oauth1a/access_token_spec.rb
+++ b/spec/cerner/oauth1a/access_token_spec.rb
@@ -83,6 +83,20 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         )
       end
     end
+
+    context 'does not raise error' do
+      it 'when oauth_version is not present' do
+        access_token = Cerner::OAuth1a::AccessToken.from_authorization_header(
+          'OAuth oauth_consumer_key="consumer key", ' \
+          'oauth_nonce="nonce", ' \
+          'oauth_timestamp="1", ' \
+          'oauth_token="token", ' \
+          'oauth_signature_method="PLAINTEXT", ' \
+          'oauth_signature="signature"'
+        )
+        expect(access_token).to be_a(Cerner::OAuth1a::AccessToken)
+      end
+    end
   end
 
   describe '#authenticate' do


### PR DESCRIPTION
### Summary
Add support for parsing tokens with no version parameter

The OAuth1a Spec says that oauth_version is optional, and if
it is not present, the version should be assumed to be 1.0

This adds one rubocop offense due to the `#from_authorization_header` method being 26 lines long. Is there a preferred fix for this? The whole class could be ignored for MethodLength or the allowed MethodLength could be increased. Alternatively, building the missing_params array could be split into its own method.

```
lib/cerner/oauth1a/access_token.rb:22:7: C: Metrics/MethodLength: Method has too many lines. [26/25]
      def self.from_authorization_header(value) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

24 files inspected, 1 offense detected
```

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Cerner OAuth 1.0a Client Library.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
