### PR TITLE
Add Protection Realm Equivalence #8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Exclude:
     - lib/cerner/oauth1a/access_token.rb
+    - lib/cerner/oauth1a/access_token_agent.rb
     - lib/cerner/oauth1a/oauth_error.rb
 Style/GuardClause:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v2.3.0
+Added Protection Realm Equivalence feature to Cerner::OAuth1a::AccessTokenAgent,
+which is used by Cerner::OAuth1a::AccessToken#authenticate when comparing realms.
+This allows for realm aliases, so that the OAuth Service can transition hosts.
 
 # v2.2.0
 Renamed the cache key prefixes from 'cerner-oauth' cache prefixes to 'cerner-oauth1a'.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for implementing a Ruby-based service.
 
     # Setup the AccessTokenAgent with an Access Token Service's URL, a Key and a Secret
     agent = Cerner::OAuth1a::AccessTokenAgent.new(
-      access_token_url: 'https://api.cernercare.com/oauth/access',
+      access_token_url: 'https://oauth-api.cerner.com/oauth/access',
       consumer_key: 'CONSUMER_KEY',
       consumer_secret: 'CONSUMER_SECRET'
     )

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ implement that:
     authz_header = request['Authorization']
 
     # Parse the header value
-    access_token = AccessToken.from_authorization_header(authz_header)
+    access_token = Cerner::OAuth1a::AccessToken.from_authorization_header(authz_header)
 
     # Authenticate the Access Token
     # Note: An AccessTokenAgent, configured with a System Account that has been granted privileges

--- a/lib/cerner/oauth1a/access_token.rb
+++ b/lib/cerner/oauth1a/access_token.rb
@@ -168,7 +168,9 @@ module Cerner
       end
 
       # Public: Authenticates the #token against the #consumer_key, #signature and side-channel
-      # secrets exchange via AccessTokenAgent#retrieve_keys.
+      # secrets exchange via AccessTokenAgent#retrieve_keys. If this instance has a #realm set,
+      # then it will compare it to the AccessTokenAgent#realm using the AccessTokenAgent#realm_eql?
+      # method.
       #
       # access_token_agent - An instance of Cerner::OAuth1a::AccessTokenAgent configured with
       #                      appropriate credentials to retrieve secrets via
@@ -182,7 +184,7 @@ module Cerner
       def authenticate(access_token_agent)
         raise ArgumentError, 'access_token_agent is nil' unless access_token_agent
 
-        if @realm && !@realm.eql?(access_token_agent.realm)
+        if @realm && !access_token_agent.realm_eql?(@realm)
           raise OAuthError.new('realm does not match provider', nil, 'token_rejected', nil, access_token_agent.realm)
         end
 

--- a/lib/cerner/oauth1a/access_token_agent.rb
+++ b/lib/cerner/oauth1a/access_token_agent.rb
@@ -22,6 +22,10 @@ module Cerner
       DEFAULT_REALM_ALIASES = {
         'https://oauth-api.cerner.com' => ['https://api.cernercare.com'].freeze,
         'https://api.cernercare.com' => ['https://oauth-api.cerner.com'].freeze,
+        'https://oauth-api.sandboxcerner.com' => ['https://api.sandboxcernercare.com'].freeze,
+        'https://api.sandboxcernercare.com' => ['https://oauth-api.sandboxcerner.com'].freeze,
+        'https://oauth-api.devcerner.com' => ['https://api.devcernercare.com'].freeze,
+        'https://api.devcernercare.com' => ['https://oauth-api.devcerner.com'].freeze
       }.freeze
 
       # Returns the URI Access Token URL.
@@ -88,7 +92,7 @@ module Cerner
         @access_token_url = convert_to_http_uri(access_token_url)
         @realm = Protocol.realm_for(@access_token_url)
         @realm_aliases = realm_aliases
-        @realm_aliases = DEFAULT_REALM_ALIASES[@realm] unless @realm_aliases
+        @realm_aliases ||= DEFAULT_REALM_ALIASES[@realm]
 
         @open_timeout = (open_timeout ? open_timeout.to_i : 5)
         @read_timeout = (read_timeout ? read_timeout.to_i : 5)

--- a/lib/cerner/oauth1a/access_token_agent.rb
+++ b/lib/cerner/oauth1a/access_token_agent.rb
@@ -19,14 +19,21 @@ module Cerner
     class AccessTokenAgent
       MIME_WWW_FORM_URL_ENCODED = 'application/x-www-form-urlencoded'
 
+      DEFAULT_REALM_ALIASES = {
+        'https://oauth-api.cerner.com' => ['https://api.cernercare.com'].freeze,
+        'https://api.cernercare.com' => ['https://oauth-api.cerner.com'].freeze,
+      }.freeze
+
       # Returns the URI Access Token URL.
       attr_reader :access_token_url
       # Returns the String Consumer Key.
       attr_reader :consumer_key
       # Returns the String Consumer Secret.
       attr_reader :consumer_secret
-      # Returns the String Protection Realm. The realm is root of the access_token_url (scheme + hostname).
+      # Returns the String Protection Realm. The realm is root of the access_token_url (Protocol#realm_for).
       attr_reader :realm
+      # Returns the Array of Protection Realm String that are considered equivalent (#realm_eql?) to #realm.
+      attr_reader :realm_aliases
 
       # Public: Constructs an instance of the agent.
       #
@@ -55,6 +62,10 @@ module Cerner
       #                                    #retrieve_keys. (optional, default: true)
       #             :cache_access_tokens - A Boolean for configuring AccessToken caching within
       #                                    #retrieve. (optional, default: true)
+      #             :realm_aliases       - An Array of Strings that provide realm aliases for the
+      #                                    realm that's extracted from :access_token_url. If nil,
+      #                                    this will be initalized with the DEFAULT_REALM_ALIASES.
+      #                                    (optional, default: nil)
       #
       # Raises ArgumentError if access_token_url, consumer_key or consumer_key is nil; if
       #                      access_token_url is an invalid URI.
@@ -65,7 +76,8 @@ module Cerner
         open_timeout: 5,
         read_timeout: 5,
         cache_keys: true,
-        cache_access_tokens: true
+        cache_access_tokens: true,
+        realm_aliases: nil
       )
         raise ArgumentError, 'consumer_key is nil' unless consumer_key
         raise ArgumentError, 'consumer_secret is nil' unless consumer_secret
@@ -74,7 +86,9 @@ module Cerner
         @consumer_secret = consumer_secret
 
         @access_token_url = convert_to_http_uri(access_token_url)
-        @realm = canonical_root_url_for(@access_token_url)
+        @realm = Protocol.realm_for(@access_token_url)
+        @realm_aliases = realm_aliases
+        @realm_aliases = DEFAULT_REALM_ALIASES[@realm] unless @realm_aliases
 
         @open_timeout = (open_timeout ? open_timeout.to_i : 5)
         @read_timeout = (read_timeout ? read_timeout.to_i : 5)
@@ -167,6 +181,19 @@ module Cerner
         Time.now.to_i
       end
 
+      # Public: Determines if the passed realm is equivalent to the configured
+      # realm by comparing it to the #realm and #realm_aliases.
+      #
+      # realm - The String to check for equivalence.
+      #
+      # Returns True if the passed realm is equivalent to the configured realm;
+      #   False otherwise.
+      def realm_eql?(realm)
+        return true if @realm.eql?(realm)
+
+        @realm_aliases.include?(realm)
+      end
+
       private
 
       # Internal: Generate a User-Agent HTTP Header string
@@ -216,18 +243,6 @@ module Cerner
         raise ArgumentError, 'access_token_url must be an HTTP or HTTPS URI' unless uri.is_a?(URI::HTTP)
 
         uri
-      end
-
-      # Internal: Returns a String containing the canonical root url.
-      #
-      # url - A URL to get the canonical root url String from.
-      #
-      # raises ArgumentError if url is nil.
-      def canonical_root_url_for(url)
-        raise ArgumentError, 'url is nil' unless url
-
-        realm = URI("#{url.scheme}://#{url.host}:#{url.port}")
-        realm.to_s
       end
 
       # Internal: Prepare a request for #retrieve

--- a/lib/cerner/oauth1a/protocol.rb
+++ b/lib/cerner/oauth1a/protocol.rb
@@ -134,6 +134,22 @@ module Cerner
 
         default
       end
+
+      # Public: Returns a String containing a realm value from the URI. The
+      # String will be a rooted (path removed) and canonicalized URL of the
+      # URL passed.
+      #
+      # uri - A URI instance containing the URL to construct the realm for.
+      #
+      # Returns a String containing the realm value.
+      #
+      # Raises ArgumentError if uri is nil.
+      def self.realm_for(uri)
+        raise ArgumentError, 'uri is nil' unless uri
+
+        realm = URI("#{uri.scheme}://#{uri.host}:#{uri.port}")
+        realm.to_s
+      end
     end
   end
 end

--- a/spec/cerner/oauth1a/access_token_agent_spec.rb
+++ b/spec/cerner/oauth1a/access_token_agent_spec.rb
@@ -10,6 +10,59 @@ require 'cerner/oauth1a/oauth_error'
 require 'json'
 
 RSpec.describe Cerner::OAuth1a::AccessTokenAgent do
+  describe '#realm_eql?' do
+    context 'initalized realm_aliases to empty' do
+      it 'returns true' do
+        agent = Cerner::OAuth1a::AccessTokenAgent.new(
+          access_token_url: 'https://oauth-api.cerner.com/oauth/access',
+          consumer_key: 'CONSUMER KEY',
+          consumer_secret: 'CONSUMER SECRET',
+          realm_aliases: []
+        )
+        expect(agent.realm_eql?('https://oauth-api.cerner.com')).to be true
+      end
+
+      it 'returns false' do
+        agent = Cerner::OAuth1a::AccessTokenAgent.new(
+          access_token_url: 'https://api.cernercare.com/oauth/access',
+          consumer_key: 'CONSUMER KEY',
+          consumer_secret: 'CONSUMER SECRET',
+          realm_aliases: []
+        )
+        expect(agent.realm_eql?('https://oauth-api.cerner.com')).to be false
+      end
+    end
+
+    context 'initalized realm_aliases to default' do
+      it 'returns true when the same' do
+        agent = Cerner::OAuth1a::AccessTokenAgent.new(
+          access_token_url: 'https://oauth-api.cerner.com/oauth/access',
+          consumer_key: 'CONSUMER KEY',
+          consumer_secret: 'CONSUMER SECRET'
+        )
+        expect(agent.realm_eql?('https://oauth-api.cerner.com')).to be true
+      end
+
+      it 'returns true when an alias' do
+        agent = Cerner::OAuth1a::AccessTokenAgent.new(
+          access_token_url: 'https://api.cernercare.com/oauth/access',
+          consumer_key: 'CONSUMER KEY',
+          consumer_secret: 'CONSUMER SECRET'
+        )
+        expect(agent.realm_eql?('https://oauth-api.cerner.com')).to be true
+      end
+
+      it 'returns false' do
+        agent = Cerner::OAuth1a::AccessTokenAgent.new(
+          access_token_url: 'https://api.cernercare.com/oauth/access',
+          consumer_key: 'CONSUMER KEY',
+          consumer_secret: 'CONSUMER SECRET'
+        )
+        expect(agent.realm_eql?('https://not-equal')).to be false
+      end
+    end
+  end
+
   describe '#retrieve_keys' do
     before(:all) do
       @server = MockAccessTokenServer.new(

--- a/spec/cerner/oauth1a/access_token_spec.rb
+++ b/spec/cerner/oauth1a/access_token_spec.rb
@@ -123,7 +123,8 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).twice.and_return('AGENT REALM')
+        expect(ata).to receive(:realm).and_return('AGENT REALM')
+        expect(ata).to receive(:realm_eql?).and_return(false)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'token_rejected'
@@ -141,7 +142,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'signature_method_rejected'
@@ -158,7 +159,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'consumer_key_rejected'
@@ -175,7 +176,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'missing ExpiresOn'
@@ -192,7 +193,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'token_expired'
@@ -209,7 +210,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
           realm: 'REALM'
         )
         ata = double('AccessTokenAgent')
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'missing KeysVersion'
@@ -229,7 +230,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(ata).to(
           receive(:retrieve_keys).with('2').and_raise(Cerner::OAuth1a::OAuthError, 'invalid keys')
         )
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'token references invalid keys version'
@@ -249,7 +250,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(keys).to receive(:verify_rsasha1_signature).and_return(false)
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'not authentic'
@@ -269,7 +270,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(keys).to receive(:verify_rsasha1_signature).and_return(true)
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'missing signature'
@@ -290,7 +291,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(keys).to receive(:verify_rsasha1_signature).and_return(true)
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'missing HMACSecrets'
@@ -312,7 +313,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         expect(keys).to receive(:decrypt_hmac_secrets).with('SECRETS').and_raise(ArgumentError, 'SIMULATED_FAILURE')
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'SIMULATED_FAILURE'
@@ -338,7 +339,7 @@ RSpec.describe Cerner::OAuth1a::AccessToken do
         )
         ata = double('AccessTokenAgent')
         expect(ata).to receive(:retrieve_keys).with('1').and_return(keys)
-        expect(ata).to receive(:realm).and_return('REALM')
+        expect(ata).to receive(:realm_eql?).and_return(true)
         expect { at.authenticate(ata) }.to raise_error do |error|
           expect(error).to be_a(Cerner::OAuth1a::OAuthError)
           expect(error.message).to include 'signature_invalid'

--- a/spec/cerner/oauth1a/protocol_spec.rb
+++ b/spec/cerner/oauth1a/protocol_spec.rb
@@ -5,6 +5,32 @@ require 'spec_helper'
 require 'cerner/oauth1a/protocol'
 
 RSpec.describe Cerner::OAuth1a::Protocol do
+  describe '.realm_for' do
+    it 'raises ArgumentError with nil input' do
+      expect { Cerner::OAuth1a::Protocol.realm_for(nil) }.to raise_error ArgumentError
+    end
+
+    context 'returns rooted and canonical URL String' do
+      it 'when input includes a path' do
+        expect(
+          Cerner::OAuth1a::Protocol.realm_for(URI('https://oauth-api.cerner.com/oauth/access'))
+        ).to eq('https://oauth-api.cerner.com')
+      end
+
+      it 'when input does not include a path' do
+        expect(
+          Cerner::OAuth1a::Protocol.realm_for(URI('https://oauth-api.cerner.com'))
+        ).to eq('https://oauth-api.cerner.com')
+      end
+
+      it 'when input includes a port' do
+        expect(
+          Cerner::OAuth1a::Protocol.realm_for(URI('https://oauth-api.cerner.com:8443'))
+        ).to eq('https://oauth-api.cerner.com:8443')
+      end
+    end
+  end
+
   describe '.parse_url_query_string' do
     it 'raises ArgumentError with nil input' do
       expect { Cerner::OAuth1a::Protocol.parse_url_query_string(nil) }.to raise_error ArgumentError


### PR DESCRIPTION
### Summary
Added Protection Realm Equivalence feature to Cerner::OAuth1a::AccessTokenAgent,
which is used by Cerner::OAuth1a::AccessToken#authenticate when comparing realms.
This allows for realm aliases, so that the OAuth Service can transition hosts.

Related to issue #8 