### PR TITLE
Rework the parse of the Authorization/WWW-Authenticate header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,10 @@ Layout/HeredocIndentation:
   Enabled: true
 Layout/IndentationConsistency:
   Enabled: true
+Layout/IndentationStyle:
+  Enabled: true
+  EnforcedStyle: spaces
+  IndentationWidth: 2
 Layout/IndentationWidth:
   Enabled: true
 Layout/InitialIndentation:
@@ -210,8 +214,6 @@ Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 Layout/SpaceInsideStringInterpolation:
   Enabled: true
-Layout/Tab:
-  Enabled: true
 Layout/TrailingEmptyLines:
   Enabled: true
 Layout/TrailingWhitespace:
@@ -257,8 +259,6 @@ Lint/EmptyExpression:
 Lint/EmptyInterpolation:
   Enabled: true
 Lint/EmptyWhen:
-  Enabled: true
-Lint/EndInMethod:
   Enabled: true
 Lint/EnsureReturn:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.5.2
+Adjust `Cerner::OAuth1a::Protocol.parse_www_authenticate_header` to handle parameters
+that are either tokens or quoted strings.
+
 # v2.5.1
 Address `instance variable @cache_instance not initialized` warning
 

--- a/lib/cerner/oauth1a/protocol.rb
+++ b/lib/cerner/oauth1a/protocol.rb
@@ -49,6 +49,10 @@ module Cerner
       #   Cerner::OAuth1a::Protocol.parse_www_authenticate_header(header)
       #   # => {:realm=>"https://test.host", :oauth_problem=>"token_expired"}
       #
+      #   header = 'OAuth realm="https://test.host", oauth_problem=token_expired'
+      #   Cerner::OAuth1a::Protocol.parse_www_authenticate_header(header)
+      #   # => {:realm=>"https://test.host", :oauth_problem=>"token_expired"}
+      #
       # Returns a Hash with symbolized keys of all of the parameters.
       def self.parse_authorization_header(value)
         params = {}

--- a/lib/cerner/oauth1a/protocol.rb
+++ b/lib/cerner/oauth1a/protocol.rb
@@ -62,7 +62,7 @@ module Cerner
         return params unless value.size > 6 && value[0..5].casecmp?('OAuth ')
 
         # trim off 'OAuth ' prefix
-        value = value[6..]
+        value = value[6..-1]
 
         # split value on comma separators
         value.split(/,\s*/).each do |kv_part|

--- a/lib/cerner/oauth1a/protocol.rb
+++ b/lib/cerner/oauth1a/protocol.rb
@@ -57,10 +57,18 @@ module Cerner
         value = value.strip
         return params unless value.size > 6 && value[0..5].casecmp?('OAuth ')
 
-        value.scan(/([^,\s=]*)=\"([^\"]*)\"/).each do |pair|
-          k = URI.decode_www_form_component(pair[0])
-          v = URI.decode_www_form_component(pair[1])
-          params[k.to_sym] = v
+        # trim off 'OAuth ' prefix
+        value = value[6..]
+
+        # split value on comma separators
+        value.split(/,\s*/).each do |kv_part|
+          # split each part on '=' separator
+          key, value = kv_part.split('=')
+          key = URI.decode_www_form_component(key)
+          # trim off surrounding double quotes, if they exist
+          value = value[1..-2] if value.start_with?('"') && value.end_with?('"')
+          value = URI.decode_www_form_component(value)
+          params[key.to_sym] = value
         end
 
         params

--- a/lib/cerner/oauth1a/version.rb
+++ b/lib/cerner/oauth1a/version.rb
@@ -2,6 +2,6 @@
 
 module Cerner
   module OAuth1a
-    VERSION = '2.6.0'
+    VERSION = '2.5.2'
   end
 end

--- a/spec/cerner/oauth1a/protocol_spec.rb
+++ b/spec/cerner/oauth1a/protocol_spec.rb
@@ -121,19 +121,25 @@ RSpec.describe(Cerner::OAuth1a::Protocol) do
   describe '.parse_www_authenticate_header' do
     it 'returns params when both are quoted-string' do
       expect(
-        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com",oauth_problem="token_expired"')
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header(
+          'OAuth realm="https://oauth-api.cerner.com",oauth_problem="token_expired"'
+        )
       ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
     end
 
     it 'returns params when one is quoted-string and one is token' do
       expect(
-        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com",oauth_problem=token_expired')
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header(
+          'OAuth realm="https://oauth-api.cerner.com",oauth_problem=token_expired'
+        )
       ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
     end
 
     it 'returns params when there is whitespace' do
       expect(
-        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com", oauth_problem=token_expired')
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header(
+          'OAuth realm="https://oauth-api.cerner.com", oauth_problem=token_expired'
+        )
       ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
     end
 

--- a/spec/cerner/oauth1a/protocol_spec.rb
+++ b/spec/cerner/oauth1a/protocol_spec.rb
@@ -118,11 +118,37 @@ RSpec.describe(Cerner::OAuth1a::Protocol) do
     end
   end
 
+  describe '.parse_www_authenticate_header' do
+    it 'returns params when both are quoted-string' do
+      expect(
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com",oauth_problem="token_expired"')
+      ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
+    end
+
+    it 'returns params when one is quoted-string and one is token' do
+      expect(
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com",oauth_problem=token_expired')
+      ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
+    end
+
+    it 'returns params when there is whitespace' do
+      expect(
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth realm="https://oauth-api.cerner.com", oauth_problem=token_expired')
+      ).to(eq(realm: 'https://oauth-api.cerner.com', oauth_problem: 'token_expired'))
+    end
+
+    it 'returns param when it is token' do
+      expect(
+        Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth oauth_problem=token_expired')
+      ).to(eq(oauth_problem: 'token_expired'))
+    end
+  end
+
   describe '.parse_authorization_header' do
     context 'alias form' do
       it 'returns Hash with encoded values' do
         expect(
-          Cerner::OAuth1a::Protocol.parse_authorization_header('OAuth oauth_token="token%23token"')
+          Cerner::OAuth1a::Protocol.parse_www_authenticate_header('OAuth oauth_token="token%23token"')
         ).to(eq(oauth_token: 'token#token'))
       end
     end


### PR DESCRIPTION
handle both quoted strings and tokens per https://tools.ietf.org/html/rfc7235#appendix-C.

